### PR TITLE
fix: models import error

### DIFF
--- a/autumn/client.py
+++ b/autumn/client.py
@@ -130,7 +130,7 @@ class Client:
 
         Returns
         -------
-        :class:`~autumn.types.response.AttachResponse`
+        :class:`~autumn.models.response.AttachResponse`
             The response from the API.
         """
 
@@ -183,7 +183,7 @@ class Client:
 
         Returns
         -------
-        :class:`~autumn.types.response.CheckResponse`
+        :class:`~autumn.models.response.CheckResponse`
             The response from the API.
         """
 
@@ -232,7 +232,7 @@ class Client:
 
         Returns
         -------
-        :class:`~autumn.types.response.TrackResponse`
+        :class:`~autumn.models.response.TrackResponse`
             The response from the API.
         """
         payload = _build_payload(locals(), self.track)

--- a/autumn/customers.py
+++ b/autumn/customers.py
@@ -56,7 +56,7 @@ class Customers(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.customers.Customer`
+        :class:`~autumn.models.customers.Customer`
             The customer.
         """
         return self._http.request("GET", f"/customers/{customer_id}", Customer)
@@ -106,7 +106,7 @@ class Customers(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.customers.Customer`
+        :class:`~autumn.models.customers.Customer`
             The created customer.
         """
         payload = _build_payload(locals(), self.create)  # type: ignore
@@ -157,7 +157,7 @@ class Customers(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.customers.Customer`
+        :class:`~autumn.models.customers.Customer`
             The updated customer.
         """
         payload = _build_payload(locals(), self.update, ignore={"customer_id"})  # type: ignore
@@ -200,7 +200,7 @@ class Customers(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.BillingPortalResponse`
+        :class:`~autumn.models.response.BillingPortalResponse`
             The billing portal URL.
         """
         payload = _build_payload(
@@ -239,7 +239,7 @@ class Customers(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.PricingTableResponse`
+        :class:`~autumn.models.response.PricingTableResponse`
             The pricing table.
         """
         params = {"customer_id": customer_id}

--- a/autumn/features.py
+++ b/autumn/features.py
@@ -64,7 +64,7 @@ class Features(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.Empty`
+        :class:`~autumn.models.response.Empty`
             This is a placeholder type. Treat it as :class:`None`.
         """
         payload = _build_payload(locals(), self.set_usage, ignore={"customer_id"})  # type: ignore
@@ -100,12 +100,12 @@ class Features(Generic[T_HttpClient]):
         ----------
         customer_id: str
             The ID of the customer to set the balances for.
-        balances: List[:class:`~autumn.types.balance.Balance`]
+        balances: List[:class:`~autumn.models.balance.Balance`]
             The balances to set for the customer.
 
         Returns
         -------
-        :class:`~autumn.types.response.Empty`
+        :class:`~autumn.models.response.Empty`
             This is a placeholder type. Treat it as :class:`None`.
         """
 
@@ -152,7 +152,7 @@ class Features(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.Empty`
+        :class:`~autumn.models.response.Empty`
             This is a placeholder type. Treat it as :class:`None`.
         """
 
@@ -225,7 +225,7 @@ class Features(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.Empty`
+        :class:`~autumn.models.response.Empty`
             This is a placeholder type. Treat it as :class:`None`.
         """
 

--- a/autumn/products.py
+++ b/autumn/products.py
@@ -12,8 +12,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from .types.products import ProductItem, FreeTrial
-from .types.response import (
+from .models.products import ProductItem, FreeTrial
+from .models.response import (
     CreateProductResponse,
     GetProductResponse,
     ReferralCodeResponse,
@@ -111,7 +111,7 @@ class Products(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.CreateProductResponse`
+        :class:`~autumn.models.response.CreateProductResponse`
             The response from the API.
         """
         payload = _build_payload(locals(), self.create)  # type: ignore
@@ -145,7 +145,7 @@ class Products(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.GetProductResponse`
+        :class:`~autumn.models.response.GetProductResponse`
             The response from the API.
         """
         return self._http.request("GET", f"/products/{id}", GetProductResponse)
@@ -182,7 +182,7 @@ class Products(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.ReferralCodeResponse`
+        :class:`~autumn.models.response.ReferralCodeResponse`
             The response from the API.
         """
 
@@ -231,7 +231,7 @@ class Products(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.ReferralRedeemResponse`
+        :class:`~autumn.models.response.ReferralRedeemResponse`
             The response from the API.
         """
         payload = _build_payload(locals(), self.redeem_referral_code)  # type: ignore
@@ -249,7 +249,7 @@ class Products(Generic[T_HttpClient]):
         product_id: str,
         *,
         entity_id: Optional[str] = None,
-        cancel_immediately: bool = False
+        cancel_immediately: bool = False,
     ) -> ProductCancelResponse: ...
 
     @overload
@@ -259,7 +259,7 @@ class Products(Generic[T_HttpClient]):
         product_id: str,
         *,
         entity_id: Optional[str] = None,
-        cancel_immediately: bool = False
+        cancel_immediately: bool = False,
     ) -> Coroutine[Any, Any, ProductCancelResponse]: ...
 
     def cancel(
@@ -268,7 +268,7 @@ class Products(Generic[T_HttpClient]):
         product_id: str,
         *,
         entity_id: Optional[str] = None,
-        cancel_immediately: bool = False
+        cancel_immediately: bool = False,
     ) -> Union[ProductCancelResponse, Coroutine[Any, Any, ProductCancelResponse]]:
         """Cancel a product for a customer.
 
@@ -287,7 +287,7 @@ class Products(Generic[T_HttpClient]):
 
         Returns
         -------
-        :class:`~autumn.types.response.ProductCancelResponse`
+        :class:`~autumn.models.response.ProductCancelResponse`
             The response from the API.
         """
         payload = _build_payload(locals(), self.cancel_product)  # type: ignore


### PR DESCRIPTION
## Aims of this PR

Fixed incorrect import paths for models in the `autumn.products.py` file and updated documentation that referenced the old `autumn.types` directory.

**Key changes:**
- Updated import statements from `.types.*` to `.models.*` in `products.py`, `customers.py`, `client.py`, and `features.py`
- Fixed all docstring references from `autumn.types.*` to `autumn.models.*`

## Checklist

- [x] Have code changes been tested?
- [x] Has documentation been updated?
- [x] Does this PR fix an issue?
- [ ] Does this PR make breaking changes?

**Additional context**
Thank you for making this SDK! It will be very useful for me.