### PR TITLE
Fix: CheckResponse model

### DIFF
--- a/autumn/models/response.py
+++ b/autumn/models/response.py
@@ -28,8 +28,8 @@ class CheckResponse(BaseModel):
     feature_id: Optional[str] = None
     product_id: Optional[str] = None
     status: Optional[str] = None
-    feature_preview: FeaturePreview
-    product_preview: ProductPreview
+    feature_preview: Optional[FeaturePreview] = None
+    product_preview: Optional[ProductPreview] = None
 
 
 class TrackResponse(BaseModel):


### PR DESCRIPTION

The error:
```
autumn.error.AutumnValidationError: validation_error: Field required at ('feature_preview',) with code missing
Received response: {'customer_id': '2f37e8f0-cfd2-4794-9653-3d455aa4e020', 'code': 'product_found', 'product_id': 'freemium', 'allowed': True, 'status': 'active'}
```

When one of or both preview items are not the output of the check api call, what will be always the case, the model check raise an error becaus the items are missing.

Solution:

In `CheckResponse`  model set `feature_preview` and `product_preview` items as optional.