### PR TITLE
fix: support camelCase request payload params

### DIFF
--- a/autumn/utils.py
+++ b/autumn/utils.py
@@ -8,6 +8,11 @@ from .error import AutumnHTTPError, AutumnValidationError
 T = TypeVar("T", bound=BaseModel)
 
 
+def _snake_to_camel(snake_str: str) -> str:
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
+
+
 def _decompose_value(value: Any) -> Any:
     if isinstance(value, BaseModel):
         return value.model_dump()
@@ -21,16 +26,22 @@ def _build_payload(
     scope: Dict[str, Any], method: Callable, *, ignore: Set[str] = set()
 ) -> Dict[str, Any]:
     params = method.__code__.co_varnames
+    camel_case_params = [_snake_to_camel(p) for p in params]
     payload: Dict[str, Any] = {}
 
     for key, value in scope.items():
+        payload_param = key
+        if payload_param in camel_case_params:
+            index = camel_case_params.index(payload_param)
+            payload_param = params[index]
+
         if (
-            key != "self"
-            and (key in params)
-            and (key not in ignore)
+            payload_param != "self"
+            and (payload_param in params)
+            and (payload_param not in ignore)
             and (value is not None)
         ):
-            payload[key] = _decompose_value(value)
+            payload[payload_param] = _decompose_value(value)
 
     return payload
 

--- a/tests/asgi/test_routes_core.py
+++ b/tests/asgi/test_routes_core.py
@@ -1,0 +1,307 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from pydantic import BaseModel
+from starlette.responses import JSONResponse
+
+from autumn.asgi.routes import core
+from autumn.client import Client
+from autumn.models.response import AttachResponse, CheckResponse, TrackResponse
+
+
+DUMMY_CUSTOMER_ID = "user_123"
+DUMMY_AUTUMN_SECRET_KEY = "sk_test_a1b2c3d4e5f6g7h8i9j0"
+DUMMY_IDENTIFY_RETURN_VALUE = {"customer_id": DUMMY_CUSTOMER_ID, "customer_data": {}}
+
+
+class DummyRequest:
+    def __init__(self, state_obj):
+        self.state = state_obj
+        self._json = None
+
+    async def json(self):
+        return getattr(self, "_json", None)
+
+
+def _setup_http_mock(autumn: Client, mock_response: BaseModel | None) -> None:
+    autumn.http.request = AsyncMock(return_value=mock_response)
+
+
+def _prepare_request(
+    json_payload=None, mock_response: BaseModel | None = None
+) -> DummyRequest:
+    autumn = Client(token=DUMMY_AUTUMN_SECRET_KEY)
+
+    _setup_http_mock(autumn, mock_response)
+
+    identify = AsyncMock(return_value=DUMMY_IDENTIFY_RETURN_VALUE)
+    autumn_obj = {"identify": identify, "client": autumn}
+
+    State = type("State", (), {})
+    state_obj = State()
+    setattr(state_obj, "__autumn__", autumn_obj)
+
+    request = DummyRequest(state_obj)
+    if json_payload is not None:
+        request._json = json_payload
+
+    return request
+
+
+@pytest.mark.asyncio
+async def test_attach_route_with_product_id():
+    json_payload = {"product_id": "product_123"}
+
+    mock_response = AttachResponse(
+        code="success",
+        message="Attached",
+        checkout_url="https://checkout.example.com",
+        customer_id=DUMMY_CUSTOMER_ID,
+        product_ids=["product_123"],
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.check_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_attach_route_with_product_id_camel_case():
+    json_payload = {"productId": "product_123"}
+
+    mock_response = AttachResponse(
+        code="success",
+        message="Attached",
+        checkout_url="https://checkout.example.com",
+        customer_id=DUMMY_CUSTOMER_ID,
+        product_ids=["product_123"],
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.attach_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_attach_route_with_product_ids():
+    json_payload = {"product_ids": ["product_123", "product_456"]}
+
+    mock_response = AttachResponse(
+        code="success",
+        message="Attached",
+        checkout_url="https://checkout.example.com",
+        customer_id=DUMMY_CUSTOMER_ID,
+        product_ids=["product_123", "product_456"],
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.attach_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_attach_route_with_product_ids_camel_case():
+    json_payload = {"productIds": ["product_123", "product_456"]}
+
+    mock_response = AttachResponse(
+        code="success",
+        message="Attached",
+        checkout_url="https://checkout.example.com",
+        customer_id=DUMMY_CUSTOMER_ID,
+        product_ids=["product_123", "product_456"],
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.attach_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_attach_route_without_product_id_or_product_ids():
+    json_payload = {}
+
+    request = _prepare_request(json_payload)
+
+    try:
+        await core.attach_route(request)  # type: ignore
+        assert False, "Should have raised AssertionError"
+    except AssertionError as e:
+        assert "Either product_id or product_ids must be provided" in str(e)
+
+
+@pytest.mark.asyncio
+async def test_check_route_with_product_id():
+    json_payload = {"product_id": "product_123"}
+
+    mock_response = CheckResponse(
+        allowed=True,
+        code="success",
+        balance=100.0,
+        customer_id=DUMMY_CUSTOMER_ID,
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.check_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_check_route_with_product_id_camel_case():
+    json_payload = {"productId": "product_123"}
+
+    mock_response = CheckResponse(
+        allowed=True,
+        code="success",
+        balance=100.0,
+        customer_id=DUMMY_CUSTOMER_ID,
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.check_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_check_route_with_feature_id():
+    json_payload = {"feature_id": "feature_123"}
+
+    mock_response = CheckResponse(
+        allowed=True,
+        code="success",
+        balance=100.0,
+        customer_id=DUMMY_CUSTOMER_ID,
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.check_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_check_route_with_feature_id_camel_case():
+    json_payload = {"featureId": "feature_123"}
+
+    mock_response = CheckResponse(
+        allowed=True,
+        code="success",
+        balance=100.0,
+        customer_id=DUMMY_CUSTOMER_ID,
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.check_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_check_route_without_product_id_or_feature_id():
+    json_payload = {}
+
+    request = _prepare_request(json_payload)
+
+    try:
+        await core.check_route(request)  # type: ignore
+        assert False, "Should have raised AssertionError"
+    except AssertionError as e:
+        assert "Either product_id or feature_id must be provided" in str(e)
+
+
+@pytest.mark.asyncio
+async def test_track_route_with_feature_id():
+    json_payload = {"feature_id": "feature_123"}
+
+    mock_response = TrackResponse(
+        id="track_123",
+        code="success",
+        customer_id=DUMMY_CUSTOMER_ID,
+        feature_id="feature_123",
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.track_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_track_route_with_feature_id_camel_case():
+    json_payload = {"featureId": "feature_123"}
+
+    mock_response = TrackResponse(
+        id="track_123",
+        code="success",
+        customer_id=DUMMY_CUSTOMER_ID,
+        feature_id="feature_123",
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.track_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_track_route_with_event_name():
+    json_payload = {"event_name": "event_123"}
+
+    mock_response = TrackResponse(
+        id="track_123",
+        code="success",
+        customer_id=DUMMY_CUSTOMER_ID,
+        event_name="event_123",
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.track_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_track_route_with_event_name_camel_case():
+    json_payload = {"eventName": "event_123"}
+
+    mock_response = TrackResponse(
+        id="track_123",
+        code="success",
+        customer_id=DUMMY_CUSTOMER_ID,
+        event_name="event_123",
+    )
+
+    request = _prepare_request(json_payload, mock_response)
+
+    response = await core.track_route(request)  # type: ignore
+
+    assert isinstance(response, JSONResponse)
+
+
+@pytest.mark.asyncio
+async def test_track_route_without_feature_id_or_event_name():
+    json_payload = {}
+
+    request = _prepare_request(json_payload)
+
+    try:
+        await core.track_route(request)  # type: ignore
+        assert False, "Should have raised AssertionError"
+    except AssertionError as e:
+        assert "Either feature_id or event_name must be provided" in str(e)


### PR DESCRIPTION
## **Bug Report**

### **Describe the bug**
Using version 3.1.1 of the `autumn-py` ASGI framework on the backend and version 0.1.40 of the `autumn-js` package on the frontend results in client side requests to the "check", "attach", and "checkout" Autumn backend routes being rejected with 400 Bad Request status codes due to missing parameters in the request payload.

### **To Reproduce**
Use the ASGI client of "autumn-py==3.1.1" on the backend and the `useCustomer` hook of "autumn-js@0.1.40" on the frontend to make a request to any of the "check", "attach", or "checkout" Autumn API routes.

Alternatively, I've created a modified version of the "React + Python Autumn Starter Template" repository that is setup to reproduce the issue. Here's a link:
[autumn-py-camel-case-issue repository](https://github.com/jeremylevasseur/autumn-py-camel-case-issue)

### **Expected behavior**
Client side requests made with the `autumn-js` hooks to the "check", "attach", and "checkout" Autumn backend routes should not result in 400 Bad Request responses.

### **Screenshots**
Here is a video of the issue occurring:
[camelCase-request-payload-params-issue.webm](https://github.com/user-attachments/assets/c5f5f420-df5a-4cc9-b2c1-753cae61330e)

### **Version Information**
Python SDK Version: `3.1.1`
Python Version: `3.12.9`
JS Client Version: `0.1.40`

## **Pull Request**

### **Aims of this PR**
Resolve the issue by updating the function which builds payloads for the `autumn-py` client to handle camelCase parameters within a request payload gracefully.

### **Checklist**

- [x] Have code changes been tested?
- [ ] Has documentation been updated?
- [x] Does this PR fix an issue?
- [ ] Does this PR make breaking changes?

### **Additional context**
I've added some tests for the changes.