### PR TITLE
fix: add missing 'hosted_invoice_url' field to CustomerInvoice model

### DIFF
--- a/autumn/models/customers.py
+++ b/autumn/models/customers.py
@@ -43,6 +43,7 @@ class CustomerInvoice(BaseModel):
     total: float
     currency: str
     created_at: int
+    hosted_invoice_url: str
 
 
 class CustomerFeature(BaseModel):


### PR DESCRIPTION
## Aims of this PR

Fixes an issue where the invoice objects of the Autumn client's `customers.get` method response do not contain invoice URLs.

**Key changes:**
- Added a `hosted_invoice_url` field to the `CustomerInvoice` model.

## Checklist

- [x] Have code changes been tested?
- [ ] Has documentation been updated?
- [x] Does this PR fix an issue?
- [ ] Does this PR make breaking changes?

**Additional context**

Used the `CustomerInvoice` interface from the `autumn-js` package as a reference for this new field:
https://github.com/useautumn/typescript/blob/main/package/src/sdk/customers/cusTypes.ts#L171